### PR TITLE
Fixes an edge case with org reuse

### DIFF
--- a/force-app/main/default/classes/Shared Code/RecipeTreeViewController.cls
+++ b/force-app/main/default/classes/Shared Code/RecipeTreeViewController.cls
@@ -8,6 +8,12 @@ public inherited sharing class RecipeTreeViewController {
     private static Map<String, List<String>> groupToListOfNames;
 
     /**
+     * @description The String here represents a relatively unique tag that
+     * Apex Recipe uses to help group related classes.
+     */
+    private static final String APEXRECIPESIDENTIFICATIONTAG = '* @group';
+
+    /**
      * @description Used to marshall data between Apex and the LWC component
      * that uses this data
      */
@@ -103,11 +109,12 @@ public inherited sharing class RecipeTreeViewController {
     @SuppressWarnings('PMD.ApexCRUDViolation')
     private static Map<String, List<String>> generateMapOfGroupToListOfNames() {
         Map<String, List<String>> returnMap = new Map<String, List<String>>();
-        ApexClass[] classes = [
-            SELECT Name, Body
-            FROM ApexClass
-            WHERE NOT Name LIKE '%_Tests'
+        List<List<SObject>> searchResults = [
+            FIND :APEXRECIPESIDENTIFICATIONTAG
+            IN ALL FIELDS
+            RETURNING ApexClass(Name, Body)
         ];
+        ApexClass[] classes = searchResults[0];
 
         for (ApexClass klass : classes) {
             String groupName = ApexClassUtilities.getGroupFromClassBody(klass);

--- a/force-app/main/default/staticresources/documentation/docs/docs/RecipeTreeViewController.md
+++ b/force-app/main/default/staticresources/documentation/docs/docs/RecipeTreeViewController.md
@@ -12,6 +12,10 @@ Provides the necessary data to populate a lightning-tree base component with rec
 ---
 ## Properties
 
+### `APEXRECIPESIDENTIFICATIONTAG` → `String`
+
+The String here represents a relatively unique tag that Apex Recipe uses to help group related classes.
+
 ### `groupToListOfNames` → `List<String>>`
 
 ---

--- a/force-app/main/default/staticresources/documentation/docs/docs/RestClient.md
+++ b/force-app/main/default/staticresources/documentation/docs/docs/RestClient.md
@@ -135,26 +135,6 @@ convenience version of makeApiCall without body or query params. Invokes omnibus
 |`method` |  HTTPVerb to use. See the enum above. |
 |`path` |    Http path component of the URL. ie: `/path/to/resource` |
 
-### `makeApiCall(String namedCredential,HttpVerb method,String path,String query)` → `HTTPResponse`
-
-A static wrapper for the main makeApiCall method that assumes default headers.
-
-#### Parameters
-|Param|Description|
-|-----|-----------|
-|`namedCredential` |  The named credential to use |
-|`method` |           HTTPVerb enum value. See Enum above |
-|`path` |            Http path component of the URL. ie: `/path/to/resource` |
-|`query` |            Query component of the URL ie: after `?foo=bar` |
-
-#### Example
-```java
-System.Debug(RestClient.makeApiCall('MockBin',
-                                     RestClient.HttpVerb.GET,
-                                     '4cb453a6-a23b-42ea-a6ba-9be1c1f17050',
-                                     ''));
-```
-
 ### `makeApiCall(String namedCredential,HttpVerb method,String path,String query,String body,Map<String, String> headers)` → `HTTPResponse`
 
 A static wrapper for the main makeApiCall method
@@ -177,6 +157,26 @@ System.Debug(RestClient.makeApiCall('MockBin',
                                      '',
                                      '',
                                      new Map<String,String>()));
+```
+
+### `makeApiCall(String namedCredential,HttpVerb method,String path,String query)` → `HTTPResponse`
+
+A static wrapper for the main makeApiCall method that assumes default headers.
+
+#### Parameters
+|Param|Description|
+|-----|-----------|
+|`namedCredential` |  The named credential to use |
+|`method` |           HTTPVerb enum value. See Enum above |
+|`path` |            Http path component of the URL. ie: `/path/to/resource` |
+|`query` |            Query component of the URL ie: after `?foo=bar` |
+
+#### Example
+```java
+System.Debug(RestClient.makeApiCall('MockBin',
+                                     RestClient.HttpVerb.GET,
+                                     '4cb453a6-a23b-42ea-a6ba-9be1c1f17050',
+                                     ''));
 ```
 
 ### `makeApiCall(String namedCredential,HttpVerb method,String path)` → `HTTPResponse`
@@ -218,17 +218,6 @@ convenience method for a PATCH Call that only requires a path, query and body
 |`query` |   Query component of the URL ie: after `?foo=bar` |
 |`body` |    JSON string to post |
 
-### `post(String path, String query, String body)` → `HTTPResponse`
-
-convenience method for a POST Call that only requires a path, query and body
-
-#### Parameters
-|Param|Description|
-|-----|-----------|
-|`path` |    Http path component of the URL. ie: `/path/to/resource` |
-|`query` |   Query component of the URL ie: after `?foo=bar` |
-|`body` |    JSON string to post |
-
 ### `post(String path, String body)` → `HTTPResponse`
 
 convenience method for a POST Call that only requires a path and body
@@ -239,9 +228,9 @@ convenience method for a POST Call that only requires a path and body
 |`path` |    Http path component of the URL. ie: `/path/to/resource` |
 |`body` |    JSON string to post |
 
-### `put(String path, String query, String body)` → `HTTPResponse`
+### `post(String path, String query, String body)` → `HTTPResponse`
 
-convenience method for a PUT Call that only requires a path, query and body
+convenience method for a POST Call that only requires a path, query and body
 
 #### Parameters
 |Param|Description|
@@ -258,6 +247,17 @@ convenience method for a PUT Call that only requires a path and body
 |Param|Description|
 |-----|-----------|
 |`path` |    Http path component of the URL. ie: `/path/to/resource` |
+|`body` |    JSON string to post |
+
+### `put(String path, String query, String body)` → `HTTPResponse`
+
+convenience method for a PUT Call that only requires a path, query and body
+
+#### Parameters
+|Param|Description|
+|-----|-----------|
+|`path` |    Http path component of the URL. ie: `/path/to/resource` |
+|`query` |   Query component of the URL ie: after `?foo=bar` |
 |`body` |    JSON string to post |
 
 ---

--- a/force-app/main/default/staticresources/documentation/docs/docs/TriggerHandler.md
+++ b/force-app/main/default/staticresources/documentation/docs/docs/TriggerHandler.md
@@ -155,6 +155,10 @@ In the context of a TriggerHandler class,
 this.setMaxLoopCount(5);
 ```
 
+### `setTriggerContext()` → `void`
+
+internal method to forcibly set the trigger context
+
 ### `setTriggerContext(String ctx, Boolean testMode)` → `void`
 
 Internal method for manually setting the trigger context
@@ -164,10 +168,6 @@ Internal method for manually setting the trigger context
 |-----|-----------|
 |`ctx` |       The current trigger Context |
 |`testMode` |  Is the trigger running in a test context? |
-
-### `setTriggerContext()` → `void`
-
-internal method to forcibly set the trigger context
 
 ### `validateRun()` → `Boolean`
 

--- a/force-app/tests/Shared Code/RecipeTreeViewController_Tests.cls
+++ b/force-app/tests/Shared Code/RecipeTreeViewController_Tests.cls
@@ -2,6 +2,16 @@
 private class RecipeTreeViewController_Tests {
     @isTest
     static void testGenerateTreeDataPositive() {
+        Map<Id, ApexClass> fakeResults = new Map<Id, ApexClass>(
+            [
+                SELECT Name, Body
+                FROM ApexClass
+                WHERE
+                    name LIKE 'RecipeTreeViewController'
+                    OR name LIKE 'SOQLRecipes'
+            ]
+        );
+        Test.setFixedSearchResults(new List<Id>(fakeResults.keyset()));
         Test.startTest();
         List<RecipeTreeViewController.RecipeTreeData> tree = RecipeTreeViewController.generateTreeData();
         Test.stopTest();


### PR DESCRIPTION
### What does this PR do?
The tree view controller works by querying ApexClass, and sorting the found classes by the doc block’s @group tag. When users re-use a sandbox or other org that pre-contains Apex classes that *do not* have a @group tag in the doc block, it can cause a Regex governor limit issue.

This addresses that by moving from a SOQL query, to a SOSL query looking for the @group tag in a doc block.
### What issues does this PR fix or reference?
#9 
#<Insert GitHub Issue>

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

