### PR TITLE
Fixes return type for httpCalloutWithUntypedResponse

### DIFF
--- a/force-app/main/default/staticresources/documentation/docs/docs/CalloutRecipes.md
+++ b/force-app/main/default/staticresources/documentation/docs/docs/CalloutRecipes.md
@@ -21,7 +21,7 @@ Constructor accepting a named credential.
 
 ---
 ## Methods
-### `httpCalloutWithUntypedResponse()` → `Object>`
+### `httpCalloutWithUntypedResponse()` → `Map<String, Object>`
 
 Now that we have demonstrated how to callout to an endpoint, lets take a look at what else we can do with the response. When calling out to an external endpoint, the data may not always be in a format that can be directly deserialised into a Salesforce Object. If your callout returns untyped JSON, you can deserialize this into a Map<String, Object> by using a deserializeUntyped method to convert the string.
 


### PR DESCRIPTION
### What does this PR do?
Fixes the return type for `httpCalloutWithUntypedResponse`

### What issues does this PR fix or reference?
Guess I should have created one? 

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality Before

Return type was indicated as `Object>`

### Functionality After

Return type correctly indicated as `Map<String, Object>`
