### PR TITLE
Tweaks documentation margin around method details

### DIFF
--- a/force-app/main/default/lwc/formattedDocsViewer/formattedDocsViewer.js
+++ b/force-app/main/default/lwc/formattedDocsViewer/formattedDocsViewer.js
@@ -63,7 +63,7 @@ export default class FormattedDocsViewer extends LightningElement {
     applyStyling() {
         this.applyStyleTo('h1', 'slds-text-heading_large');
         this.applyStyleTo('h2', 'slds-text-heading_medium');
-        this.applyStyleTo('h3', 'slds-text-heading_small');
+        this.applyStyleTo('h3', 'slds-text-heading_small slds-m-top_large slds-m-bottom_x-small');
         this.applyStyleTo('h4', 'slds-text-title_bold');
         this.applyStyleTo('p', 'slds-text-body_regular');
     }

--- a/force-app/main/default/lwc/formattedDocsViewer/formattedDocsViewer.js
+++ b/force-app/main/default/lwc/formattedDocsViewer/formattedDocsViewer.js
@@ -63,7 +63,10 @@ export default class FormattedDocsViewer extends LightningElement {
     applyStyling() {
         this.applyStyleTo('h1', 'slds-text-heading_large');
         this.applyStyleTo('h2', 'slds-text-heading_medium');
-        this.applyStyleTo('h3', 'slds-text-heading_small slds-m-top_large slds-m-bottom_x-small');
+        this.applyStyleTo(
+            'h3',
+            'slds-text-heading_small slds-m-top_large slds-m-bottom_x-small'
+        );
         this.applyStyleTo('h4', 'slds-text-title_bold');
         this.applyStyleTo('p', 'slds-text-body_regular');
     }


### PR DESCRIPTION
### What does this PR do?
Adds spacing between method documentation by adding margin in and around h3 tags in the generated markup. Clearly this may not be desired on all h3 tags but markdown doesn't offer much flexibility here.

This hasn't been extensively tested, I grepped through the docs and a quick scan appears that `###` is only used for methods but I may have missed something... it may also not be fully legit SLDS, I never did learn much of that :) 



### What issues does this PR fix or reference?
Whoops :)

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality Before

![image](https://user-images.githubusercontent.com/1256283/96117624-1c288400-0f36-11eb-8ca5-f44fba0fdfff.png)


### Functionality After

![image](https://user-images.githubusercontent.com/1256283/96117724-3eba9d00-0f36-11eb-8356-1a2a2e96b6e0.png)

