### PR TITLE
Define Trigger.newMap and Trigger.oldMap in a Trigger Handler

### DIFF
--- a/force-app/main/default/classes/Trigger Recipes/AccountTriggerHandler.cls
+++ b/force-app/main/default/classes/Trigger Recipes/AccountTriggerHandler.cls
@@ -5,8 +5,8 @@
  * @see TriggerHandler, AccountServiceLayer
  */
 public inherited sharing class AccountTriggerHandler extends TriggerHandler {
-    private List<Account> triggerOld;
-    private List<Account> triggerNew;
+    private List<Account> triggerOld, List<Account> triggerNew;
+    private Map<Id, Account> triggerMapNew, triggerMapOld;
 
     @TestVisible
     private static Exception circuitBreaker;
@@ -24,6 +24,8 @@ public inherited sharing class AccountTriggerHandler extends TriggerHandler {
     public AccountTriggerHandler() {
         this.triggerOld = (List<Account>) Trigger.old;
         this.triggerNew = (List<Account>) Trigger.new;
+        this.triggerMapNew = (Map<Id, Account>) Trigger.newMap;
+        this.triggerMapOld = (Map<Id, Account>) Trigger.oldMap;
     }
 
     // Insert Contexts


### PR DESCRIPTION
I like to always define both old/new Lists as well as the old/new Maps in the Handler class.

### What does this PR do?

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
