### PR TITLE
Default new Scratch Orgs to English Language + orgInit Powershell Script 

### DIFF
--- a/bin/orgInit.ps1
+++ b/bin/orgInit.ps1
@@ -1,0 +1,15 @@
+param([int]$duration)
+
+if (!$duration) {
+    $duration = 7
+}
+
+sfdx force:org:create -f config/project-scratch-def.json --setalias ApexRecipes --durationdays $duration --setdefaultusername --json --loglevel fatal
+sfdx force:source:push
+sfdx force:user:permset:assign -n Apex_Recipes
+sfdx force:user:permset:assign -n Walkthroughs
+sfdx force:data:tree:import -p ./data/data-plan.json
+sfdx force:data:tree:import -p ./data/data-plan2.json
+sfdx force:apex:execute --apexcodefile data/setup.apex
+sfdx force:org:open
+Write-Host "Org is set up"

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,6 +1,8 @@
 {
     "orgName": "Apex Recipes",
     "edition": "Developer",
+    "country": "US",
+    "language": "en_US",
     "features": ["TransactionFinalizers", "Walkthroughs", "PlatformCache"],
     "settings": {
         "lightningExperienceSettings": {


### PR DESCRIPTION
### What does this PR do?

- makes sure that all scratch orgs created via `project-scratch-def.json` default to English language
- adds a PowerShell `*.ps1` script file for windows users - cloned from `orgInit.sh`

### What issues does this PR fix or reference?

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[X] Code linting and formatting was performed.

### Functionality Before

- Depending on the DevHub involved, new scratch orgs for Apex Recipes were Non-English Orgs

### Functionality After

- Independent of DevHub, all new scratch orgs for Apex Recipes are English Orgs. 
