### PR TITLE
Added chunk’d soql for loop recipe

### DIFF
--- a/force-app/main/default/classes/Data Recipes/SOQLRecipes.cls
+++ b/force-app/main/default/classes/Data Recipes/SOQLRecipes.cls
@@ -47,6 +47,29 @@ public inherited sharing class SOQLRecipes {
     }
 
     /**
+     * @description One of the little known features of SOQL for loops is that
+     * you can iterate not only over each record returned by the query, but also
+     * over each *chunk of records*. As the code below demonstrates, specifying
+     * the iteration variable as a list/array will return 200 record chunks
+     * from the query, rather than individual records.
+     * @return      `Integer`
+     */
+    public static Integer[] getChunksOfLargeNumbersOfRecords() {
+        Integer countOfChunks = 0;
+        Integer recordCount = 0;
+
+        for (List<Account> accounts : [
+            SELECT Name
+            FROM Account
+            WITH SECURITY_ENFORCED
+        ]) {
+            countOfChunks += 1;
+            recordCount += accounts.size();
+        }
+        return new List<Integer>{ countOfChunks, recordCount };
+    }
+
+    /**
      * @description Demonstrates how to use a WHERE clause in a SOQL query
      *
      * @return List<Account>

--- a/force-app/main/default/classes/Data Recipes/SOQLRecipes.cls
+++ b/force-app/main/default/classes/Data Recipes/SOQLRecipes.cls
@@ -52,6 +52,11 @@ public inherited sharing class SOQLRecipes {
      * over each *chunk of records*. As the code below demonstrates, specifying
      * the iteration variable as a list/array will return 200 record chunks
      * from the query, rather than individual records.
+     *
+     * Note: Normally, if you're only dealing with counts of records, you'd
+     * utilize the Count() soql method, but in this case we're demonstrating
+     * that this form of a soql for loop gives you access both to a list of
+     * records, and to the records themselves.
      * @return      `Integer`
      */
     public static Integer[] getChunksOfLargeNumbersOfRecords() {

--- a/force-app/main/default/staticresources/documentation/docs/docs/SOQLRecipes.md
+++ b/force-app/main/default/staticresources/documentation/docs/docs/SOQLRecipes.md
@@ -37,7 +37,7 @@ System.debug(SOQLRecipes.getAccountRecordsInState('ks'));
 
 ### `getChunksOfLargeNumbersOfRecords()` → `Integer[]`
 
-One of the little known features of SOQL for loops is that you can iterate not only over each record returned by the query, but also over each *chunk of records*. As the code below demonstrates, specifying the iteration variable as a list/array will return 200 record chunks from the query, rather than individual records.
+One of the little known features of SOQL for loops is that you can iterate not only over each record returned by the query, but also over each *chunk of records*. As the code below demonstrates, specifying the iteration variable as a list/array will return 200 record chunks from the query, rather than individual records. Note: Normally, if you're only dealing with counts of records, you'd utilize the Count() soql method, but in this case we're demonstrating that this form of a soql for loop gives you access both to a list of records, and to the records themselves.
 
 #### Return
 

--- a/force-app/main/default/staticresources/documentation/docs/docs/SOQLRecipes.md
+++ b/force-app/main/default/staticresources/documentation/docs/docs/SOQLRecipes.md
@@ -35,6 +35,20 @@ List<Account>
 System.debug(SOQLRecipes.getAccountRecordsInState('ks'));
 ```
 
+### `getChunksOfLargeNumbersOfRecords()` → `Integer[]`
+
+One of the little known features of SOQL for loops is that you can iterate not only over each record returned by the query, but also over each *chunk of records*. As the code below demonstrates, specifying the iteration variable as a list/array will return 200 record chunks from the query, rather than individual records.
+
+#### Return
+
+**Type**
+
+Integer[]
+
+**Description**
+
+`Integer`
+
 ### `getDetailsFromBothParentRecords()` → `List<Junction__c>`
 
 Demonstrates how to write a query that pulls information from two parent objects through a junction object

--- a/force-app/tests/Data Recipes/SOQLRecipes_Tests.cls
+++ b/force-app/tests/Data Recipes/SOQLRecipes_Tests.cls
@@ -63,7 +63,7 @@ private class SOQLRecipes_Tests {
         TestDataHelpers.createAccount(false, '');
 
         System.assertEquals(
-            [SELECT Id FROM Account].size(),
+            [SELECT COUNT() FROM Account],
             1,
             'Expected only one account'
         );
@@ -95,7 +95,7 @@ private class SOQLRecipes_Tests {
         TestFactory.createSObjectList(new Account(), 3000, true);
 
         System.assertEquals(
-            [SELECT Id FROM Account].size(),
+            [SELECT COUNT() FROM Account],
             3000,
             'expected to have created 3k records'
         );
@@ -124,7 +124,7 @@ private class SOQLRecipes_Tests {
         TestFactory.createSObjectList(new Account(), 3000, true);
 
         System.assertEquals(
-            [SELECT Id FROM Account].size(),
+            [SELECT COUNT() FROM Account],
             3000,
             'expected to have created 3k records'
         );
@@ -146,7 +146,7 @@ private class SOQLRecipes_Tests {
     static void testQueryWithFilterWithNoMatchingAcctsPositive() {
         TestDataHelpers.createAccount(false, '');
         System.assertEquals(
-            [SELECT Id FROM Account].size(),
+            [SELECT COUNT() FROM Account],
             1,
             'Expected only one account'
         );
@@ -164,7 +164,7 @@ private class SOQLRecipes_Tests {
     static void testQueryWithFilterNegativeNoPermsToAccountNegative() {
         TestDataHelpers.createAccount(true, 'UK');
         System.assertEquals(
-            [SELECT ID FROM ACCOUNT].size(),
+            [SELECT COUNT() FROM ACCOUNT],
             1,
             'expected only one account'
         );
@@ -204,7 +204,7 @@ private class SOQLRecipes_Tests {
     static void testQueryWithFilterPositive() {
         TestDataHelpers.createAccount(true, 'UK');
         System.assertEquals(
-            [SELECT Id FROM Account].size(),
+            [SELECT COUNT() FROM Account],
             1,
             'Expected only one account'
         );

--- a/force-app/tests/Data Recipes/SOQLRecipes_Tests.cls
+++ b/force-app/tests/Data Recipes/SOQLRecipes_Tests.cls
@@ -106,6 +106,11 @@ private class SOQLRecipes_Tests {
     }
 
     @isTest
+    /**
+     * @description This test method demonstrates an alternative form of a soql
+     * for loop. This form gives you lists of records, rather than one record
+     * at a time.
+     */
     static void testGetChunksOfLargeNumbersOfRecords() {
         /**
          * this next line is a feature of the trigger handler in use

--- a/force-app/tests/Data Recipes/SOQLRecipes_Tests.cls
+++ b/force-app/tests/Data Recipes/SOQLRecipes_Tests.cls
@@ -105,6 +105,35 @@ private class SOQLRecipes_Tests {
         System.assertEquals(count, 3000, 'Expected to find 3k records');
     }
 
+    @isTest
+    static void testGetChunksOfLargeNumbersOfRecords() {
+        /**
+         * this next line is a feature of the trigger handler in use
+         * it demonstrates the kinds of gotcha's you can hit when testing large data volumes
+         * in this case we need 3k accounts - but inserting them means running two triggers
+         * Creating those 3k accounts exceeds our CPU governor limit. By inserting after
+         * setting the TriggerHandler bypass for accountTriggerHandler, the trigger framework will
+         * skip that particular set of triggers.
+         */
+        TriggerHandler.bypass('AccountTriggerHandler');
+        TestFactory.createSObjectList(new Account(), 3000, true);
+
+        System.assertEquals(
+            [SELECT Id FROM Account].size(),
+            3000,
+            'expected to have created 3k records'
+        );
+        Test.startTest();
+        Integer[] counts = SOQLRecipes.getChunksOfLargeNumbersOfRecords();
+        Test.stopTest(); // forces all asych work to complete
+        System.assertEquals(
+            15,
+            counts[0],
+            'Expected the chunk count to be 15 - 3000 / 200'
+        );
+        System.assertEquals(3000, counts[1], 'Expected to find 3k records');
+    }
+
     /**
      * @description Executes a positive test case against getRecordsByFieldValue
      */


### PR DESCRIPTION
### What does this PR do?

Add's an additional SOQL Recipe that I was specifically asked for. Demonstrates how to use a Soql for loop with 200 record chunks, rather than 1 by 1. 
