### PR TITLE
Fix Custom Metadata records not found for Custom Objects.

### DIFF
--- a/force-app/main/default/classes/Trigger Recipes/MetadataTriggerService.cls
+++ b/force-app/main/default/classes/Trigger Recipes/MetadataTriggerService.cls
@@ -24,7 +24,7 @@ public with sharing class MetadataTriggerService {
             SELECT Class__c
             FROM Metadata_Driven_Trigger__mdt
             WHERE
-                Object__c = :this.objType
+                Object__r.QualifiedApiName = :this.objType
                 AND Enabled__c = TRUE
                 AND Id NOT IN (
                     SELECT Metadata_Driven_Trigger__c


### PR DESCRIPTION


### What does this PR do?
Fix Custom Metadata records not found for Custom Objects.

### What issues does this PR fix or reference?

# https://github.com/trailheadapps/apex-recipes/issues/125

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

Custom Metadata record wasn't found as Object__c is an Id for custom objects

### Functionality After

Object__r.QualifiedApiName is a API name for Standard and Custom Objects
