### PR TITLE
feat: use ruleset.xml instead of default PMD security

### DIFF
--- a/.github/workflows/ci-pr-prerelease.yml
+++ b/.github/workflows/ci-pr-prerelease.yml
@@ -64,7 +64,7 @@ jobs:
                   tar xJf sfdx-linux-x64.tar.xz -C ~/sfdx --strip-components 1
                   echo "$HOME/sfdx/bin" >> $GITHUB_PATH
                   ~/sfdx/bin/sfdx version
-                  
+
             # Install Salesforce CLI Scanner
             - name: 'Install Salesforce CLI Scanner'
               run: sfdx plugins:install @salesforce/sfdx-scanner
@@ -72,7 +72,7 @@ jobs:
             # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
-              
+
             # Run Salesforce CLI Scanner For Security checks
             - name: 'Scan For Security Exceptions'
               run: sfdx scanner:run --pmdconfig ruleset.xml --target ./force-app --engine pmd -v

--- a/.github/workflows/ci-pr-prerelease.yml
+++ b/.github/workflows/ci-pr-prerelease.yml
@@ -64,10 +64,18 @@ jobs:
                   tar xJf sfdx-linux-x64.tar.xz -C ~/sfdx --strip-components 1
                   echo "$HOME/sfdx/bin" >> $GITHUB_PATH
                   ~/sfdx/bin/sfdx version
+                  
+            # Install Salesforce CLI Scanner
+            - name: 'Install Salesforce CLI Scanner'
+              run: sfdx plugins:install @salesforce/sfdx-scanner
 
             # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
+              
+            # Run Salesforce CLI Scanner For Security checks
+            - name: 'Scan For Security Exceptions'
+              run: sfdx scanner:run --pmdconfig ruleset.xml --target ./force-app --engine pmd -v
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -86,7 +86,7 @@ jobs:
 
             # Run Salesforce CLI Scanner For Security checks
             - name: 'Scan For Security Exceptions'
-              run: sfdx scanner:run -c=Security -t=./force-app -f=json -v
+              run: sfdx scanner:run —-pmdconfig "./ruleset.xml" -e=pmd -t=./force-app -f=json -v
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -86,7 +86,7 @@ jobs:
 
             # Run Salesforce CLI Scanner For Security checks
             - name: 'Scan For Security Exceptions'
-              run: sfdx scanner:run -e=pmd -t=./force-app -f=json -v —-pmdconfig="ruleset.xml"
+              run: sfdx scanner:run --pmdconfig ruleref.xml --target ./force-app --engine pmd -v
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -86,7 +86,7 @@ jobs:
 
             # Run Salesforce CLI Scanner For Security checks
             - name: 'Scan For Security Exceptions'
-              run: sfdx scanner:run --pmdconfig ruleref.xml --target ./force-app --engine pmd -v
+              run: sfdx scanner:run --pmdconfig ruleset.xml --target ./force-app --engine pmd -v
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -86,7 +86,7 @@ jobs:
 
             # Run Salesforce CLI Scanner For Security checks
             - name: 'Scan For Security Exceptions'
-              run: sfdx scanner:run -e=pmd -t=./force-app -f=json -v —-pmdconfig "ruleset.xml"
+              run: sfdx scanner:run -e=pmd -t=./force-app -f=json -v —-pmdconfig="ruleset.xml"
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -86,7 +86,7 @@ jobs:
 
             # Run Salesforce CLI Scanner For Security checks
             - name: 'Scan For Security Exceptions'
-              run: sfdx scanner:run —-pmdconfig "./ruleset.xml" -e=pmd -t=./force-app -f=json -v
+              run: sfdx scanner:run -e=pmd -t=./force-app -f=json -v —-pmdconfig "ruleset.xml"
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,18 @@
 # Unique name for this workflow
-name: CI on PR
+name: CI
 
 # Definition when the workflow should run
 on:
-    pull_request:
-        types: [opened, edited, synchronize, reopened]
-        branches-ignore:
-            - prerelease/spring[2-9][0-9]
-            - prerelease/summer[2-9][0-9]
-            - prerelease/winter[2-9][0-9]
+    push:
+        branches:
+            - main
+        paths-ignore:
+            - 'sfdx-project.json'
+            - 'README.md'
 
 # Jobs to be executed
 jobs:
-    # Dummy job used to skip CI run on automated PRs
-    skip-ci:
-        if: "github.actor == 'trailheadapps-bot'"
-        runs-on: ubuntu-latest
-        steps:
-            - name: Noop
-              run: |
-                  echo "Skipping CI run for automated PRs."
-
-    # Formatting only runs on human-submitted PRs
     formatting:
-        if: "github.actor != 'trailheadapps-bot'"
         runs-on: ubuntu-latest
         steps:
             # Checkout the source code
@@ -76,17 +65,9 @@ jobs:
                   echo "$HOME/sfdx/bin" >> $GITHUB_PATH
                   ~/sfdx/bin/sfdx version
 
-            # Install Salesforce CLI Scanner
-            - name: 'Install Salesforce CLI Scanner'
-              run: sfdx plugins:install @salesforce/sfdx-scanner
-
             # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
-
-            # Run Salesforce CLI Scanner For Security checks
-            - name: 'Scan For Security Exceptions'
-              run: sfdx scanner:run —-pmdconfig "./ruleset.xml" -e=pmd -t=./force-app -f=json -v
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'
@@ -120,9 +101,29 @@ jobs:
               if: always()
               run: sfdx force:org:delete -p -u scratch-org
 
-    trigger-packaging:
+    publish-docs-to-wiki:
         runs-on: ubuntu-latest
         needs: scratch-org-test
+        steps:
+            # Checkout the code
+            - name: 'Checkout source code'
+              uses: actions/checkout@v2
+
+            # Fetch history
+            - name: 'Fetch history'
+              run: git fetch origin ${{ github.event.before }} --depth=1
+
+            # Upload documentation to wiki
+            - name: 'Upload documentation to wiki'
+              uses: SwiftDocOrg/github-wiki-publish-action@v1
+              with:
+                  path: 'force-app/main/default/staticresources/documentation/docs/docs'
+              env:
+                  GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.BOT_ACCESS_TOKEN }}
+
+    trigger-packaging:
+        runs-on: ubuntu-latest
+        needs: publish-docs-to-wiki
         steps:
             # Checkout the source code
             - name: 'Checkout source code'
@@ -132,8 +133,8 @@ jobs:
             - name: 'Check for package changes'
               id: checkForChanges
               run: |
-                  git fetch origin $GITHUB_BASE_REF --depth=1
-                  changedPaths=$( git diff-tree --name-only origin/$GITHUB_BASE_REF $GITHUB_SHA )
+                  git fetch origin ${{ github.event.before }} --depth=1
+                  changedPaths=$( git diff-tree --name-only ${{ github.event.before }} $GITHUB_SHA )
                   set +e
                   hasChanges='false'
                   if [ $(echo "$changedPaths" | grep -c '^force-app') == 1 ]; then
@@ -141,11 +142,11 @@ jobs:
                   fi
                   echo "::set-output name=hasChanges::$hasChanges"
 
-            # Trigger packaging PR workflow
-            - name: 'Trigger packaging PR workflow if needed'
+            # Trigger packaging workflow if needed
+            - name: 'Trigger packaging workflow if needed'
               uses: peter-evans/repository-dispatch@v1.1.0
               if: ${{ steps.checkForChanges.outputs.hasChanges == 'true' }}
               with:
                   token: ${{ secrets.BOT_ACCESS_TOKEN }}
-                  event-type: start-packaging-pr
+                  event-type: start-packaging
                   client-payload: '{ "ref": "${{ github.ref }}", "sha": "${{ github.sha }}" }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
                   tar xJf sfdx-linux-x64.tar.xz -C ~/sfdx --strip-components 1
                   echo "$HOME/sfdx/bin" >> $GITHUB_PATH
                   ~/sfdx/bin/sfdx version
-                  
+
             # Install Salesforce CLI Scanner
             - name: 'Install Salesforce CLI Scanner'
               run: sfdx plugins:install @salesforce/sfdx-scanner
@@ -72,7 +72,7 @@ jobs:
             # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
-              
+
             # Run Salesforce CLI Scanner For Security checks
             - name: 'Scan For Security Exceptions'
               run: sfdx scanner:run --pmdconfig ruleset.xml --target ./force-app --engine pmd -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,29 @@
 # Unique name for this workflow
-name: CI
+name: CI on PR
 
 # Definition when the workflow should run
 on:
-    push:
-        branches:
-            - main
-        paths-ignore:
-            - 'sfdx-project.json'
-            - 'README.md'
+    pull_request:
+        types: [opened, edited, synchronize, reopened]
+        branches-ignore:
+            - prerelease/spring[2-9][0-9]
+            - prerelease/summer[2-9][0-9]
+            - prerelease/winter[2-9][0-9]
 
 # Jobs to be executed
 jobs:
+    # Dummy job used to skip CI run on automated PRs
+    skip-ci:
+        if: "github.actor == 'trailheadapps-bot'"
+        runs-on: ubuntu-latest
+        steps:
+            - name: Noop
+              run: |
+                  echo "Skipping CI run for automated PRs."
+
+    # Formatting only runs on human-submitted PRs
     formatting:
+        if: "github.actor != 'trailheadapps-bot'"
         runs-on: ubuntu-latest
         steps:
             # Checkout the source code
@@ -65,9 +76,17 @@ jobs:
                   echo "$HOME/sfdx/bin" >> $GITHUB_PATH
                   ~/sfdx/bin/sfdx version
 
+            # Install Salesforce CLI Scanner
+            - name: 'Install Salesforce CLI Scanner'
+              run: sfdx plugins:install @salesforce/sfdx-scanner
+
             # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
+
+            # Run Salesforce CLI Scanner For Security checks
+            - name: 'Scan For Security Exceptions'
+              run: sfdx scanner:run —-pmdconfig "./ruleset.xml" -e=pmd -t=./force-app -f=json -v
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'
@@ -101,29 +120,9 @@ jobs:
               if: always()
               run: sfdx force:org:delete -p -u scratch-org
 
-    publish-docs-to-wiki:
-        runs-on: ubuntu-latest
-        needs: scratch-org-test
-        steps:
-            # Checkout the code
-            - name: 'Checkout source code'
-              uses: actions/checkout@v2
-
-            # Fetch history
-            - name: 'Fetch history'
-              run: git fetch origin ${{ github.event.before }} --depth=1
-
-            # Upload documentation to wiki
-            - name: 'Upload documentation to wiki'
-              uses: SwiftDocOrg/github-wiki-publish-action@v1
-              with:
-                  path: 'force-app/main/default/staticresources/documentation/docs/docs'
-              env:
-                  GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.BOT_ACCESS_TOKEN }}
-
     trigger-packaging:
         runs-on: ubuntu-latest
-        needs: publish-docs-to-wiki
+        needs: scratch-org-test
         steps:
             # Checkout the source code
             - name: 'Checkout source code'
@@ -133,8 +132,8 @@ jobs:
             - name: 'Check for package changes'
               id: checkForChanges
               run: |
-                  git fetch origin ${{ github.event.before }} --depth=1
-                  changedPaths=$( git diff-tree --name-only ${{ github.event.before }} $GITHUB_SHA )
+                  git fetch origin $GITHUB_BASE_REF --depth=1
+                  changedPaths=$( git diff-tree --name-only origin/$GITHUB_BASE_REF $GITHUB_SHA )
                   set +e
                   hasChanges='false'
                   if [ $(echo "$changedPaths" | grep -c '^force-app') == 1 ]; then
@@ -142,11 +141,11 @@ jobs:
                   fi
                   echo "::set-output name=hasChanges::$hasChanges"
 
-            # Trigger packaging workflow if needed
-            - name: 'Trigger packaging workflow if needed'
+            # Trigger packaging PR workflow
+            - name: 'Trigger packaging PR workflow if needed'
               uses: peter-evans/repository-dispatch@v1.1.0
               if: ${{ steps.checkForChanges.outputs.hasChanges == 'true' }}
               with:
                   token: ${{ secrets.BOT_ACCESS_TOKEN }}
-                  event-type: start-packaging
+                  event-type: start-packaging-pr
                   client-payload: '{ "ref": "${{ github.ref }}", "sha": "${{ github.sha }}" }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,18 @@ jobs:
                   tar xJf sfdx-linux-x64.tar.xz -C ~/sfdx --strip-components 1
                   echo "$HOME/sfdx/bin" >> $GITHUB_PATH
                   ~/sfdx/bin/sfdx version
+                  
+            # Install Salesforce CLI Scanner
+            - name: 'Install Salesforce CLI Scanner'
+              run: sfdx plugins:install @salesforce/sfdx-scanner
 
             # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
+              
+            # Run Salesforce CLI Scanner For Security checks
+            - name: 'Scan For Security Exceptions'
+              run: sfdx scanner:run --pmdconfig ruleset.xml --target ./force-app --engine pmd -v
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'

--- a/force-app/main/default/classes/Trigger Recipes/MetadataTriggerService.cls
+++ b/force-app/main/default/classes/Trigger Recipes/MetadataTriggerService.cls
@@ -19,6 +19,7 @@ public with sharing class MetadataTriggerService {
      * for all or selected individuals *without* deploying.
      * @return      `List<Metadata_Driven_Trigger__mdt>`
      */
+    @suppressWarnings('PMD.ApexCRUDViolation')
     public List<Metadata_Driven_Trigger__mdt> getMetadataTriggers() {
         return [
             SELECT Class__c

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -52,12 +52,12 @@
     >
       <priority>3</priority>
    </rule>
-   <rule
+  <!-- <rule
         ref="category/apex/security.xml/ApexCRUDViolation"
         message="Validate CRUD permission before SOQL/DML operation"
     >
       <priority>3</priority>
-   </rule>
+   </rule>-->
    <rule
         ref="category/apex/security.xml/ApexDangerousMethods"
         message="Calling potentially dangerous method"

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<ruleset
+    name="Security"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd"
+>
+
+  <description>
+These rules deal with different security problems that can occur within Apex.
+  </description>
+
+    <rule ref="category/apex/security.xml/ApexBadCrypto" deprecated="true" />
+    <rule
+        ref="category/apex/security.xml/ApexCRUDViolation"
+        deprecated="true"
+    />
+    <rule ref="category/apex/security.xml/ApexCSRF" deprecated="true" />
+    <rule
+        ref="category/apex/security.xml/ApexDangerousMethods"
+        deprecated="true"
+    />
+    <rule
+        ref="category/apex/security.xml/ApexInsecureEndpoint"
+        deprecated="true"
+    />
+    <rule ref="category/apex/security.xml/ApexOpenRedirect" deprecated="true" />
+    <rule
+        ref="category/apex/security.xml/ApexSharingViolations"
+        deprecated="true"
+    />
+    <rule
+        ref="category/apex/security.xml/ApexSOQLInjection"
+        deprecated="true"
+    />
+    <rule
+        ref="category/apex/security.xml/ApexSuggestUsingNamedCred"
+        deprecated="true"
+    />
+    <rule
+        ref="category/apex/security.xml/ApexXSSFromEscapeFalse"
+        deprecated="true"
+    />
+    <rule
+        ref="category/apex/security.xml/ApexXSSFromURLParam"
+        deprecated="true"
+    />
+
+</ruleset>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -52,12 +52,12 @@
     >
       <priority>3</priority>
    </rule>
-  <!-- <rule
+  <rule
         ref="category/apex/security.xml/ApexCRUDViolation"
         message="Validate CRUD permission before SOQL/DML operation"
     >
       <priority>3</priority>
-   </rule>-->
+   </rule>
    <rule
         ref="category/apex/security.xml/ApexDangerousMethods"
         message="Calling potentially dangerous method"

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,49 +1,73 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ruleset
-    name="Security"
+    name="Apex Security"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd"
 >
+   <description>Security Rules for Apex</description>
 
-  <description>
-These rules deal with different security problems that can occur within Apex.
-  </description>
-
-    <rule ref="category/apex/security.xml/ApexBadCrypto" deprecated="true" />
-    <rule
-        ref="category/apex/security.xml/ApexCRUDViolation"
-        deprecated="true"
-    />
-    <rule ref="category/apex/security.xml/ApexCSRF" deprecated="true" />
-    <rule
-        ref="category/apex/security.xml/ApexDangerousMethods"
-        deprecated="true"
-    />
-    <rule
-        ref="category/apex/security.xml/ApexInsecureEndpoint"
-        deprecated="true"
-    />
-    <rule ref="category/apex/security.xml/ApexOpenRedirect" deprecated="true" />
-    <rule
+   <rule
         ref="category/apex/security.xml/ApexSharingViolations"
-        deprecated="true"
-    />
-    <rule
+        message="Apex classes should declare a sharing model if DML or SOQL is used"
+    >
+      <priority>3</priority>
+   </rule>
+   <rule
+        ref="category/apex/security.xml/ApexInsecureEndpoint"
+        message="Apex callouts should use encrypted communication channels"
+    >
+      <priority>3</priority>
+   </rule>
+   <rule ref="category/apex/errorprone.xml/ApexCSRF">
+      <priority>3</priority>
+   </rule>
+   <rule
+        ref="category/apex/security.xml/ApexOpenRedirect"
+        message="Apex classes should safely redirect to a known location"
+    >
+      <priority>3</priority>
+   </rule>
+   <rule
         ref="category/apex/security.xml/ApexSOQLInjection"
-        deprecated="true"
-    />
-    <rule
-        ref="category/apex/security.xml/ApexSuggestUsingNamedCred"
-        deprecated="true"
-    />
-    <rule
-        ref="category/apex/security.xml/ApexXSSFromEscapeFalse"
-        deprecated="true"
-    />
-    <rule
+        message="Apex classes should escape variables merged in DML query"
+    >
+      <priority>3</priority>
+   </rule>
+   <rule
         ref="category/apex/security.xml/ApexXSSFromURLParam"
-        deprecated="true"
-    />
-
+        message="Apex classes should escape Strings obtained from URL parameters"
+    >
+      <priority>3</priority>
+   </rule>
+   <rule
+        ref="category/apex/security.xml/ApexXSSFromEscapeFalse"
+        message="Apex classes should escape addError strings"
+    >
+      <priority>3</priority>
+   </rule>
+   <rule
+        ref="category/apex/security.xml/ApexBadCrypto"
+        message="Apex Crypto should use random IV/key"
+    >
+      <priority>3</priority>
+   </rule>
+   <rule
+        ref="category/apex/security.xml/ApexCRUDViolation"
+        message="Validate CRUD permission before SOQL/DML operation"
+    >
+      <priority>3</priority>
+   </rule>
+   <rule
+        ref="category/apex/security.xml/ApexDangerousMethods"
+        message="Calling potentially dangerous method"
+    >
+      <priority>3</priority>
+   </rule>
+   <rule
+        ref="category/apex/security.xml/ApexSuggestUsingNamedCred"
+        message="Consider using named credentials for authenticated callouts"
+    >
+      <priority>3</priority>
+   </rule>
 </ruleset>


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

Previously we used PMD default security rules. These rules do not provide a lot of flexibility.

For example, for apex recipes, we handle CRUD/FLS checks using `CanUser` apex class. It's pain to add suppress `PMD` warning on every file where we get a false positives.

What this PR does is provides a `ruleset.xml` file and changes the scan command to use the `ruleset.xml` where we can decide which rules to keep versus which to omit.

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
