### PR TITLE
fix: auto stage docs folder after running apexdocs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "test:unit:debug": "sfdx-lwc-jest --debug --skipApiVersionCheck",
         "test:unit:coverage": "sfdx-lwc-jest --coverage --skipApiVersionCheck",
         "postinstall": "husky install",
-        "precommit": "npm run apexdocs && lint-staged"
+        "precommit": "npm run apexdocs && git add docs && lint-staged"
     },
     "lint-staged": {
         "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [


### PR DESCRIPTION
We're now staging the `docs` folder in git in the pre-commit script so that all apexdocs changes are automatically added to the commit.

```
npm run apexdocs && git add docs && lint-staged
```