### PR TITLE
EmailMessage Status and IsClientManaged on Insert

### DIFF
--- a/force-app/main/default/classes/Email Recipes/InboundEmailHandlerRecipes.cls
+++ b/force-app/main/default/classes/Email Recipes/InboundEmailHandlerRecipes.cls
@@ -169,7 +169,9 @@ public class InboundEmailHandlerRecipes implements Messaging.InboundEmailHandler
             // This is a shortcut. You should query User to find the ID of the recipient
             toIds = new List<String>{ UserInfo.getUserId() },
             Incoming = true,
-            Status = '0', // '0' -> Draft. No status for received. (yes, it's odd)
+            Status = '3', // '3' -> Sent. No status for received. (yes, it's odd)
+            // This will allow you to add incoming attachments as related ContentDocuments to the EmailMessage
+            IsClientManaged = true, 
             MessageDate = DateTime.now(),
             RelatedToId = sender.AccountId
         );


### PR DESCRIPTION
### What does this PR do?

**Changes to fields on insert of the EmailMessage from an Incoming Email**

- Updated so the `EmailMessage.Status` is set to `3` (Sent) instead of `0` (Draft)
Draft will put the email in "Upcoming and Overdue" of Activity Timeline
Sent will place it in the Activity

- Set `EmailMessage.IsClientManaged` to true
This allows you to insert/link files from the incoming email's attachments to this EmailMessage (if desired)

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

These changes don't impact the validity of the current tests, but I can add tests if desired.

[ ] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality Before

![image](https://user-images.githubusercontent.com/40637750/149120724-f5ae8b75-a134-4c00-8d6d-7cc1bf641a5e.png)


### Functionality After

![image](https://user-images.githubusercontent.com/40637750/149120596-f6e1f2ce-2134-49b0-bf8f-e56b57a183c1.png)

Reference to Issue/Enhancement Request:
#267 