### PR TITLE
ci: disabled PMD cache

### DIFF
--- a/.github/workflows/ci-pr-prerelease.yml
+++ b/.github/workflows/ci-pr-prerelease.yml
@@ -80,7 +80,7 @@ jobs:
 
             # Run PMD scan
             - name: 'Run PMD scan'
-              run: ~/pmd/bin/run.sh pmd -d force-app -R pmd/ruleset.xml -f text
+              run: ~/pmd/bin/run.sh pmd -d force-app -R pmd/ruleset.xml -f text --no-cache
 
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -91,7 +91,7 @@ jobs:
 
             # Run PMD scan
             - name: 'Run PMD scan'
-              run: ~/pmd/bin/run.sh pmd -d force-app -R pmd/ruleset.xml -f text
+              run: ~/pmd/bin/run.sh pmd -d force-app -R pmd/ruleset.xml -f text --no-cache
 
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
             # Run PMD scan
             - name: 'Run PMD scan'
-              run: ~/pmd/bin/run.sh pmd -d force-app -R pmd/ruleset.xml -f text
+              run: ~/pmd/bin/run.sh pmd -d force-app -R pmd/ruleset.xml -f text --no-cache
 
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'


### PR DESCRIPTION
Disabled PMD cache in CI workflows to get rid of this warning:
```
Jan 27, 2022 5:21:59 PM net.sourceforge.pmd.PMD encourageToUseIncrementalAnalysis
WARNING: This analysis could be faster, please consider using Incremental Analysis: https://pmd.github.io/pmd-6.41.0/pmd_userdocs_incremental_analysis.html
```