### PR TITLE
Add step to the scratch-org-test job in the CI on PR workflow to run Jest tests

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -128,6 +128,10 @@ jobs:
             - name: 'Run Apex tests'
               run: sfdx force:apex:test:run -c -r human -d ./tests/apex -w 20
 
+            # Run Jest tests
+            - name: 'Run Jest tests'
+              run: sfdx force:lightning:lwc:test:run
+
             # Delete temporary test file that Codecov is unable to parse
             - name: 'Delete coverage file (temporary step)'
               run: rm ./tests/apex/test-result-707*-codecoverage.json


### PR DESCRIPTION
### What does this PR do?
- This PR adds a step to the `scratch-org-test` job in the `CI on PR` GitHub workflow to run all Jest tests for the project when a PR is opened.

### What issues does this PR fix or reference?
- This does not fix/reference any particular issue but I thought the change could be helpful for CI in this project

## The PR fulfills these requirements:

- [x] Tests for the proposed changes have been added/updated.
- [x] Code linting and formatting was performed.

### Functionality Before

- Dependencies to run Jest tests were installed but no Jest tests were actually executed in this workflow

### Functionality After

- All Jest tests in the project should be executed when a PR is opened. This will allow users to identify any changes that may have broken or impacted component recipes
