### PR TITLE
fix: reloading docs viewer

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -18,3 +18,4 @@ package.xml
 
 # LWC Jest
 **/__tests__/**
+**/__mocks__/**

--- a/force-app/main/default/lwc/formattedDocsViewer/formattedDocsViewer.html
+++ b/force-app/main/default/lwc/formattedDocsViewer/formattedDocsViewer.html
@@ -1,5 +1,5 @@
 <template>
-    <lightning-card>
+    <lightning-card aria-label={recipeName}>
         <div
             lwc:dom="manual"
             class="slds-p-horizontal_small slds-scrollable markdownDoc"

--- a/force-app/main/default/lwc/formattedDocsViewer/formattedDocsViewer.js
+++ b/force-app/main/default/lwc/formattedDocsViewer/formattedDocsViewer.js
@@ -48,9 +48,9 @@ export default class FormattedDocsViewer extends LightningElement {
         if (this.markdownDoc && this.markdownItInitialized) {
             let docsHtml = document.createElement('div');
             docsHtml.innerHTML = this.markdownIt.render(this.markdownDoc); // eslint-disable-line
-            this.template
-                .querySelector('div.markdownDoc')
-                .appendChild(docsHtml);
+            const elem = this.template.querySelector('div.markdownDoc');
+            elem.textContent = '';
+            elem.appendChild(docsHtml);
             this.applyStyling();
         }
     }


### PR DESCRIPTION
### What does this PR do?
**TL;DR: Bug-fix: realoading document viewer.**

1. I added `{recipeName}` to the markup so that `renderedCallback()` gets called every time `recipeName` is updated. Though I'm not sure it is the best solution.
2. I updated `formatMarkdown()` function so that it replaces the existing content. (It used to just append the new content without removing the previous stuff)
3. I added `**/__mocks___/**` to `.forceignore`. Otherwise it gets deployed to the org via `sfdx force:source:deploy`.

### What issues does this PR fix or reference?

#[Issue #384](https://github.com/trailheadapps/apex-recipes/issues/384)

## The PR fulfills these requirements:

[v] Tests for the proposed changes have been added/updated.
[v] Code linting and formatting was performed.

### Functionality Before

Documentation tab doesn't reload and keeps showing docs of previous class.

### Functionality After

Documentation tab reloads and works as expected.
