### PR TITLE
Remove quotes from sample code in apex docs

### DIFF
--- a/force-app/main/default/classes/Data Recipes/SOQLRecipes.cls
+++ b/force-app/main/default/classes/Data Recipes/SOQLRecipes.cls
@@ -166,7 +166,7 @@ public with sharing class SOQLRecipes {
      *
      * @return List<Account>
      * @example
-     * System.debug('SOQLRecipes.getSecond10AccountRecords()');
+     * System.debug(SOQLRecipes.getSecond10AccountRecords());
      **/
     public static List<Account> getSecond10AccountRecords() {
         return [

--- a/force-app/main/default/staticresources/documentation/SOQLRecipes.md
+++ b/force-app/main/default/staticresources/documentation/SOQLRecipes.md
@@ -154,7 +154,7 @@ Demonstrates how to get a limited number of results with a given offset; Ie: get
 
 #### Example
 ```apex
-System.debug('SOQLRecipes.getSecond10AccountRecords()');
+System.debug(SOQLRecipes.getSecond10AccountRecords());
 ```
 
 


### PR DESCRIPTION
### What does this PR do?
In the apex docs for the SOQLRecipes.cls, the code example is shown as follows: 

``` apex
System.debug('SOQLRecipes.getSecond10AccountRecords()');
```

The trouble is, the code snippet `SOQLRecipes.getSecond10AccountRecords()` needs to be executed, not passed as a string literal. 

When run as currently committed, here's the output from exec anonymous: 

```bash
> sf apex run       
Start typing Apex code. Press the Enter key after each line, then press CTRL+D when finished.
System.debug('SOQLRecipes.getSecond10AccountRecords()');
Compiled successfully.
Executed successfully.

59.0 APEX_CODE,DEBUG;APEX_PROFILING,INFO
Execute Anonymous: System.debug('SOQLRecipes.getSecond10AccountRecords()');
15:29:36.47 (47706067)|USER_INFO|[EXTERNAL]|0058e000000ocr8|peter@apex.recipes|(GMT+00:00) Greenwich Mean Time (Europe/London)|GMTZ
15:29:36.47 (47743017)|EXECUTION_STARTED
15:29:36.47 (47761454)|CODE_UNIT_STARTED|[EXTERNAL]|execute_anonymous_apex
15:29:36.47 (48548353)|USER_DEBUG|[1]|DEBUG|SOQLRecipes.getSecond10AccountRecords()
15:29:36.48 (48692284)|CUMULATIVE_LIMIT_USAGE
15:29:36.48 (48692284)|LIMIT_USAGE_FOR_NS|(default)|
  Number of SOQL queries: 0 out of 100
  Number of query rows: 0 out of 50000
  Number of SOSL queries: 0 out of 20
  Number of DML statements: 0 out of 150
  Number of Publish Immediate DML: 0 out of 150
  Number of DML rows: 0 out of 10000
  Maximum CPU time: 0 out of 10000
  Maximum heap size: 0 out of 6000000
  Number of callouts: 0 out of 100
  Number of Email Invocations: 0 out of 10
  Number of future calls: 0 out of 50
  Number of queueable jobs added to the queue: 0 out of 50
  Number of Mobile Apex push calls: 0 out of 10

15:29:36.48 (48692284)|CUMULATIVE_LIMIT_USAGE_END

15:29:36.47 (48768612)|CODE_UNIT_FINISHED|execute_anonymous_apex
15:29:36.47 (48784518)|EXECUTION_FINISHED
```

Obviously, no soql was actually executed in this transaction. Meaning the code doesn't do what it's supposed to do: demonstrate execution of the code. 

When removing the single quotes, the transaction reports back as follows: 
```bash
> sf apex run 
Start typing Apex code. Press the Enter key after each line, then press CTRL+D when finished.
> System.debug(SOQLRecipes.getSecond10AccountRecords());
Compiled successfully.
Executed successfully.

59.0 APEX_CODE,DEBUG;APEX_PROFILING,INFO
Execute Anonymous: System.debug(SOQLRecipes.getSecond10AccountRecords());
15:31:07.123 (123137120)|USER_INFO|[EXTERNAL]|0058e000000ocr8|peter@apex.recipes|(GMT+00:00) Greenwich Mean Time (Europe/London)|GMTZ
15:31:07.123 (123174396)|EXECUTION_STARTED
15:31:07.123 (123191352)|CODE_UNIT_STARTED|[EXTERNAL]|execute_anonymous_apex
15:31:07.123 (179195355)|USER_DEBUG|[1]|DEBUG|(Account:{Id=0018e00000FSdefAAD}, Account:{Id=0018e00000FSdepAAD}, Account:{Id=0018e00000FGRKMAA5})
15:31:07.179 (179325681)|CUMULATIVE_LIMIT_USAGE
15:31:07.179 (179325681)|LIMIT_USAGE_FOR_NS|(default)|
  Number of SOQL queries: 1 out of 100
  Number of query rows: 3 out of 50000
  Number of SOSL queries: 0 out of 20
  Number of DML statements: 0 out of 150
  Number of Publish Immediate DML: 0 out of 150
  Number of DML rows: 0 out of 10000
  Maximum CPU time: 0 out of 10000
  Maximum heap size: 0 out of 6000000
  Number of callouts: 0 out of 100
  Number of Email Invocations: 0 out of 10
  Number of future calls: 0 out of 50
  Number of queueable jobs added to the queue: 0 out of 50
  Number of Mobile Apex push calls: 0 out of 10

15:31:07.179 (179325681)|CUMULATIVE_LIMIT_USAGE_END

15:31:07.123 (179445851)|CODE_UNIT_FINISHED|execute_anonymous_apex
15:31:07.123 (179457690)|EXECUTION_FINISHED

```

Here we actually get a soql query and some soql rows reported back. This is the correct invocation of the code that demonstrates the use of this method. 


### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[X] Tests for the proposed changes have been added/updated.
[X] Code linting and formatting was performed.

[no actual changes to code were made, only to comments and to documentation.]

### Functionality Before

Execution of the code did not occur

### Functionality After

The code executes as expected. 
