### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for real world solutions and should be relevant to developers of all skill level
 
 -   [Installing Apex Recipes Using an Unlocked Package](#installing-the-app-using-an-unlocked-package): This option allows anybody to experience the sample app without installing a local development environment.
 
--   [Installing Apex Recipes using a Developer Edition Org or a Trailhead Playground via the Salesforce CLI](#installing-the-app-using-a-developer-edition-org-or-a-trailhead-playground): Useful when tackling Trailhead Badges or if you want the app deployed to a more permanent environment than a Scratch org.
+-   [Installing Apex Recipes using a Developer Edition Org or a Trailhead Playground via the Salesforce CLI](#installing-the-app-using-a-developer-edition-org-or-a-trailhead-playground-via-the-salesforce-cli): Useful when tackling Trailhead Badges or if you want the app deployed to a more permanent environment than a Scratch org.
 
 -   [Optional installation instructions](#optional-installation-instructions)
 


### PR DESCRIPTION
Fixed README anchor link in Table of Contents.

### What does this PR do?
This PR corrects the anchor link for "Installing Apex Recipes using a Developer Edition Org or a Trailhead Playground via the Salesforce CLI" in the README’s Table of Contents so it points to the correct section.

## The PR fulfills these requirements:

- [ ] Tests for the proposed changes have been added/updated.
- [x] Code linting and formatting was performed.

### Functionality Before

The "Installing Apex Recipes using a Developer Edition Org..." link in the Table of Contents pointed to `#installing-the-app-using-a-developer-edition-org-or-a-trailhead-playground`, which did not match the updated section header.

### Functionality After

The link now points to `#installing-the-app-using-a-developer-edition-org-or-a-trailhead-playground-via-the-salesforce-cli`, correctly navigating to the intended section.
