### PR TITLE
feat: add Account age validation trigger

### DIFF
--- a/force-app/main/default/classes/AccountAgeTriggerTest.cls
+++ b/force-app/main/default/classes/AccountAgeTriggerTest.cls
@@ -1,0 +1,14 @@
+@IsTest
+public class AccountAgeTriggerTest {
+    @IsTest
+    static void testAccountAgeTrigger() {
+        Account acc = new Account(Name='Test Account', Age__c=-5);
+        Test.startTest();
+        try {
+            insert acc;
+        } catch(Exception e) {
+            System.assert(e.getMessage().contains('Please enter a valid Account age'));
+        }
+        Test.stopTest();
+    }
+}

--- a/force-app/main/default/triggers/AccountAgeTrigger.trigger
+++ b/force-app/main/default/triggers/AccountAgeTrigger.trigger
@@ -1,0 +1,7 @@
+trigger AccountAgeTrigger on Account (before insert, before update) {
+    for(Account acc : Trigger.new) {
+        if(acc.Age__c != null && (acc.Age__c < 0 || acc.Age__c > 150)) {
+            acc.addError('Please enter a valid Account age between 0 and 150.');
+        }
+    }
+}


### PR DESCRIPTION

This PR adds a new Apex trigger to validate Account age:

- Prevents negative or unrealistic age (>150)
- Ensures data integrity for Account records
- Includes a test class to verify the trigger works
