### PR TITLE
feat: add Opportunity stage-probability validation trigger

### DIFF
--- a/force-app/main/default/classes/OpportunityStageTriggerTest.cls
+++ b/force-app/main/default/classes/OpportunityStageTriggerTest.cls
@@ -1,0 +1,19 @@
+@IsTest
+public class OpportunityStageTriggerTest {
+    @IsTest
+    static void testStageValidation() {
+        Opportunity opp = new Opportunity(
+            Name='Test Opp',
+            StageName='Closed Won',
+            CloseDate=Date.today(),
+            Probability__c=50
+        );
+        Test.startTest();
+        try {
+            insert opp;
+        } catch(Exception e) {
+            System.assert(e.getMessage().contains('Probability must be 100% for Closed Won stage'));
+        }
+        Test.stopTest();
+    }
+}

--- a/force-app/main/default/triggers/OpportunityStageTrigger.trigger
+++ b/force-app/main/default/triggers/OpportunityStageTrigger.trigger
@@ -1,0 +1,10 @@
+trigger OpportunityStageTrigger on Opportunity (before insert, before update) {
+    for(Opportunity opp : Trigger.new) {
+        if(opp.StageName == 'Closed Won' && opp.Probability__c != 100) {
+            opp.addError('Probability must be 100% for Closed Won stage.');
+        }
+        if(opp.StageName == 'Closed Lost' && opp.Probability__c != 0) {
+            opp.addError('Probability must be 0% for Closed Lost stage.');
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new Apex trigger to validate Opportunity stage and probability:

- Ensures stage-probability consistency
- Throws error if probability is incorrect for Closed Won/Lost
- Includes a test class to verify the trigger

